### PR TITLE
Introduce ShowAssistant and CoHost

### DIFF
--- a/lib/podcast_buddy.rb
+++ b/lib/podcast_buddy.rb
@@ -46,6 +46,21 @@ module PodcastBuddy
       SystemDependency.auto_install!(:bat)
       SystemDependency.resolve_whisper_model(whisper_model)
     end
+
+    def to_human(text, label = :info)
+      case label.to_sym
+      when :info
+        Rainbow(text).blue
+      when :wait
+        Rainbow(text).yellow
+      when :input
+        Rainbow(text).black.bg(:yellow)
+      when :success
+        Rainbow(text).green
+      else
+        text
+      end
+    end
   end
 
   configure

--- a/lib/podcast_buddy.rb
+++ b/lib/podcast_buddy.rb
@@ -17,9 +17,12 @@ require_relative "podcast_buddy/session"
 require_relative "podcast_buddy/transcriber"
 require_relative "podcast_buddy/listener"
 require_relative "podcast_buddy/audio_service"
+require_relative "podcast_buddy/show_assistant"
 
 module PodcastBuddy
   class Error < StandardError; end
+
+  NamedTask = Struct.new(:name, :task, keyword_init: true)
 
   class << self
     def config

--- a/lib/podcast_buddy.rb
+++ b/lib/podcast_buddy.rb
@@ -18,6 +18,7 @@ require_relative "podcast_buddy/transcriber"
 require_relative "podcast_buddy/listener"
 require_relative "podcast_buddy/audio_service"
 require_relative "podcast_buddy/show_assistant"
+require_relative "podcast_buddy/co_host"
 
 module PodcastBuddy
   class Error < StandardError; end

--- a/lib/podcast_buddy/cli.rb
+++ b/lib/podcast_buddy/cli.rb
@@ -57,7 +57,7 @@ module PodcastBuddy
 
     def configure_logger
       if @options[:debug]
-        PodcastBuddy.logger.info to_human("Turning on debug mode...", :info)
+        PodcastBuddy.logger.info PodcastBuddy.to_human("Turning on debug mode...", :info)
         PodcastBuddy.logger.level = Logger::DEBUG
       else
         PodcastBuddy.logger.level = Logger::INFO
@@ -71,15 +71,15 @@ module PodcastBuddy
     def configure_session
       if @options[:whisper_model]
         PodcastBuddy.config.whisper_model = @options[:whisper_model]
-        PodcastBuddy.logger.info to_human("Using whisper model: #{@options[:whisper_model]}", :info)
+        PodcastBuddy.logger.info PodcastBuddy.to_human("Using whisper model: #{@options[:whisper_model]}", :info)
       end
 
       if @options[:name]
         base_path = "#{PodcastBuddy.root}/tmp/#{@options[:name]}"
         FileUtils.mkdir_p base_path
         PodcastBuddy.session = @options[:name]
-        PodcastBuddy.logger.info to_human("Using custom session name: #{@options[:name]}", :info)
-        PodcastBuddy.logger.info to_human("  Saving files to: #{PodcastBuddy.session}", :info)
+        PodcastBuddy.logger.info PodcastBuddy.to_human("Using custom session name: #{@options[:name]}", :info)
+        PodcastBuddy.logger.info PodcastBuddy.to_human("  Saving files to: #{PodcastBuddy.session}", :info)
       end
     end
 
@@ -107,7 +107,7 @@ module PodcastBuddy
     end
 
     def handle_shutdown
-      PodcastBuddy.logger.info to_human("\nShutting down streams...", :wait)
+      PodcastBuddy.logger.info PodcastBuddy.to_human("\nShutting down streams...", :wait)
       @shutdown = true
     end
 
@@ -115,29 +115,12 @@ module PodcastBuddy
       @show_assistant.stop
       @co_host&.stop
       @tasks.each do |task|
-        PodcastBuddy.logger.info to_human("Waiting for #{task.name} to shutdown...", :wait)
+        PodcastBuddy.logger.info PodcastBuddy.to_human("Waiting for #{task.name} to shutdown...", :wait)
         task&.task&.wait
       end
 
-      PodcastBuddy.logger.info to_human("Generating show notes...", :wait)
+      PodcastBuddy.logger.info PodcastBuddy.to_human("Generating show notes...", :wait)
       @show_assistant.generate_show_notes
-    end
-
-    private
-
-    def to_human(text, label = :info)
-      case label.to_sym
-      when :info
-        Rainbow(text).blue
-      when :wait
-        Rainbow(text).yellow
-      when :input
-        Rainbow(text).black.bg(:yellow)
-      when :success
-        Rainbow(text).green
-      else
-        text
-      end
     end
   end
 end

--- a/lib/podcast_buddy/co_host.rb
+++ b/lib/podcast_buddy/co_host.rb
@@ -60,6 +60,7 @@ module PodcastBuddy
         PodcastBuddy.logger.debug("Input received...") if input.include?("\n")
         if input.include?("\n")
           @listening_for_question_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if @listening_for_question_at.nil?
+          @listener.suppress_what_you_hear!
           @question_buffer = ""
         end
       rescue Timeout::Error
@@ -88,6 +89,7 @@ module PodcastBuddy
         else
           PodcastBuddy.logger.info "End of question signal. Generating answer..."
           @listening_for_question_at = nil
+          @listener.announce_what_you_hear!
           answer_question(@question_buffer).wait
           break
         end

--- a/lib/podcast_buddy/co_host.rb
+++ b/lib/podcast_buddy/co_host.rb
@@ -28,7 +28,9 @@ module PodcastBuddy
           wait_for_question_start
           next unless @listening_for_question_at
 
-          PodcastBuddy.logger.info to_human("🎙️ Listening for question. Press ", :wait) + to_human("Enter", :input) + to_human(" to signal the end of the question...", :wait)
+          PodcastBuddy.logger.info PodcastBuddy.to_human("🎙️ Listening for question. Press ", :wait) +
+            PodcastBuddy.to_human("Enter", :input) +
+            PodcastBuddy.to_human(" to signal the end of the question...", :wait)
           wait_for_question_end
         end
       end
@@ -42,7 +44,7 @@ module PodcastBuddy
 
     def handle_transcription(data)
       if question_listening_started_before?(data[:started_at])
-        PodcastBuddy.logger.info "Heard Question: #{data[:text]}"
+        PodcastBuddy.logger.info PodcastBuddy.to_human("Heard Question: #{data[:text]}", :wait)
         @question_buffer << data[:text]
       end
     end
@@ -112,21 +114,6 @@ module PodcastBuddy
         PodcastBuddy.logger.debug("Answer converted to speech: #{PodcastBuddy.answer_audio_file_path}")
         PodcastBuddy.logger.debug("Playing answer...")
         @audio_service.play_audio(PodcastBuddy.answer_audio_file_path)
-      end
-    end
-
-    def to_human(text, label = :info)
-      case label.to_sym
-      when :info
-        Rainbow(text).blue
-      when :wait
-        Rainbow(text).yellow
-      when :input
-        Rainbow(text).black.bg(:yellow)
-      when :success
-        Rainbow(text).green
-      else
-        text
       end
     end
   end

--- a/lib/podcast_buddy/co_host.rb
+++ b/lib/podcast_buddy/co_host.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: false
+
+module PodcastBuddy
+  # Handles active podcast participation including:
+  # - Question detection
+  # - Answer generation
+  # - Text-to-speech response
+  # - Audio playback
+  class CoHost
+    attr_reader :listener
+
+    def initialize(listener:, audio_service: AudioService.new)
+      @listener = listener
+      @audio_service = audio_service
+      @shutdown = false
+      @question_buffer = ""
+      @listening_for_question_at = nil
+      @notified_input_toggle = false
+      @listener.subscribe { |data| handle_transcription(data) }
+    end
+
+    def start
+      Async do |parent|
+        loop do
+          PodcastBuddy.logger.debug("Shutdown: wait_for_question...") and break if @shutdown
+
+          PodcastBuddy.logger.info Rainbow("Press ").blue + Rainbow("Enter").black.bg(:yellow) + Rainbow(" to signal a question start...").blue
+          wait_for_question_start
+          next unless @listening_for_question_at
+
+          PodcastBuddy.logger.info to_human("🎙️ Listening for question. Press ", :wait) + to_human("Enter", :input) + to_human(" to signal the end of the question...", :wait)
+          wait_for_question_end
+        end
+      end
+    end
+
+    def stop
+      @shutdown = true
+    end
+
+    private
+
+    def handle_transcription(data)
+      if question_listening_started_before?(data[:started_at])
+        PodcastBuddy.logger.info "Heard Question: #{data[:text]}"
+        @question_buffer << data[:text]
+      end
+    end
+
+    def question_listening_started_before?(start)
+      @listening_for_question_at && start <= @listening_for_question_at
+    end
+
+    def wait_for_question_start
+      input = ""
+      Timeout.timeout(5) do
+        input = gets
+        PodcastBuddy.logger.debug("Input received...") if input.include?("\n")
+        if input.include?("\n")
+          @listening_for_question_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) if @listening_for_question_at.nil?
+          @question_buffer = ""
+        end
+      rescue Timeout::Error
+        return
+      end
+    end
+
+    def wait_for_question_end
+      loop do
+        PodcastBuddy.logger.debug("Shutdown: wait_for_question_end...") and break if @shutdown
+
+        sleep 0.1 and next if @listening_for_question_at.nil?
+
+        input = ""
+        Timeout.timeout(5) do
+          input = gets
+          PodcastBuddy.logger.debug("Input received...") if input.include?("\n")
+          next unless input.to_s.include?("\n")
+        rescue Timeout::Error
+          PodcastBuddy.logger.debug("Input timeout...")
+          next
+        end
+
+        if input.empty?
+          next
+        else
+          PodcastBuddy.logger.info "End of question signal. Generating answer..."
+          @listening_for_question_at = nil
+          answer_question(@question_buffer).wait
+          break
+        end
+      end
+    end
+
+    def answer_question(question)
+      Async do
+        latest_context = "#{PodcastBuddy.session.current_summary}\nTopics discussed recently:\n---\n#{PodcastBuddy.session.current_topics.split("\n").last(10)}\n---\n"
+        previous_discussion = @listener.transcriber.latest(1_000)
+        PodcastBuddy.logger.info "Answering question:\n#{question}"
+        PodcastBuddy.logger.debug "Context:\n---#{latest_context}\n---\nPrevious discussion:\n---#{previous_discussion}\n---\nAnswering question:\n---#{question}\n---"
+        response = PodcastBuddy.openai_client.chat(parameters: {
+          model: "gpt-4o-mini",
+          messages: [
+            {role: "system", content: format(PodcastBuddy.config.discussion_system_prompt, {summary: PodcastBuddy.current_summary})},
+            {role: "user", content: question}
+          ],
+          max_tokens: 150
+        })
+        answer = response.dig("choices", 0, "message", "content").strip
+        PodcastBuddy.logger.debug "Answer: #{answer}"
+        @audio_service.text_to_speech(answer, PodcastBuddy.answer_audio_file_path)
+        PodcastBuddy.logger.debug("Answer converted to speech: #{PodcastBuddy.answer_audio_file_path}")
+        PodcastBuddy.logger.debug("Playing answer...")
+        @audio_service.play_audio(PodcastBuddy.answer_audio_file_path)
+      end
+    end
+
+    def to_human(text, label = :info)
+      case label.to_sym
+      when :info
+        Rainbow(text).blue
+      when :wait
+        Rainbow(text).yellow
+      when :input
+        Rainbow(text).black.bg(:yellow)
+      when :success
+        Rainbow(text).green
+      else
+        text
+      end
+    end
+  end
+end

--- a/lib/podcast_buddy/knowledge.md
+++ b/lib/podcast_buddy/knowledge.md
@@ -11,10 +11,10 @@ Handles passive podcast assistance:
 
 ### CoHost
 Handles active podcast participation:
-- Question detection
-- Answer generation
-- Text-to-speech response
-- Audio playback
+- Question detection via user input (Enter key)
+- Answer generation using GPT-4
+- Text-to-speech response using OpenAI TTS
+- Audio playback via system audio
 
 ## Design Goals
 - Each service should be independently runnable

--- a/lib/podcast_buddy/knowledge.md
+++ b/lib/podcast_buddy/knowledge.md
@@ -1,0 +1,23 @@
+# PodcastBuddy Service Architecture
+
+## Core Services
+
+### ShowAssistant
+Handles passive podcast assistance:
+- Continuous transcription
+- Periodic summarization
+- Topic extraction
+- Show notes generation
+
+### CoHost
+Handles active podcast participation:
+- Question detection
+- Answer generation
+- Text-to-speech response
+- Audio playback
+
+## Design Goals
+- Each service should be independently runnable
+- Services share common resources (Session, Configuration)
+- Communication between services via PodSignal
+- Clear separation between passive monitoring and active participation

--- a/lib/podcast_buddy/listener.rb
+++ b/lib/podcast_buddy/listener.rb
@@ -16,6 +16,7 @@ module PodcastBuddy
       @whisper_logger = whisper_logger || PodcastBuddy.whisper_logger
       @transcription_signal = PodSignal.new
       @listening_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @announce_hearing = true
     end
 
     # Start the listening process
@@ -51,6 +52,14 @@ module PodcastBuddy
       @transcription_signal.subscribe(&block)
     end
 
+    def announce_what_you_hear!
+      @announce_hearing = true
+    end
+
+    def suppress_what_you_hear!
+      @announce_hearing = false
+    end
+
     private
 
     # Process a single transcription line
@@ -59,10 +68,10 @@ module PodcastBuddy
       text = @transcriber.process(line)
       return if text.empty?
 
-      PodcastBuddy.logger.info "Heard: #{text}"
+      PodcastBuddy.logger.info "Heard: #{text}" if @announce_hearing
       PodcastBuddy.update_transcript(text)
       @transcription_queue << text
-      @transcription_signal.trigger({ text: text, started_at: @listening_start })
+      @transcription_signal.trigger({text: text, started_at: @listening_start})
       text
     end
   end

--- a/lib/podcast_buddy/listener.rb
+++ b/lib/podcast_buddy/listener.rb
@@ -4,12 +4,6 @@ module PodcastBuddy
     # @return [Queue] queue for storing transcriptions
     attr_reader :transcription_queue, :transcriber
 
-    # @return [Queue] queue for storing questions
-    attr_reader :question_queue
-
-    # @return [Boolean] indicates if currently listening for a question
-    attr_reader :listening_for_question
-
     # Initialize a new Listener
     # @param transcriber [PodcastBuddy::Transcriber] the transcriber to use
     # @param whisper_command [String] the system command to use for streaming whisper
@@ -17,12 +11,11 @@ module PodcastBuddy
     def initialize(transcriber:, whisper_command: PodcastBuddy.whisper_command, whisper_logger: PodcastBuddy.whisper_logger)
       @transcriber = transcriber
       @transcription_queue = Queue.new
-      @question_queue = Queue.new
-      @current_discussion = ""
-      @listening_for_question = false
       @shutdown = false
       @whisper_command = whisper_command || PodcastBuddy.whisper_command
       @whisper_logger = whisper_logger || PodcastBuddy.whisper_logger
+      @transcription_signal = PodSignal.new
+      @listening_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     # Start the listening process
@@ -54,27 +47,8 @@ module PodcastBuddy
       @shutdown = true
     end
 
-    # Enter question listening mode
-    def listen_for_question!
-      @listening_for_question = true
-      @question_queue.clear
-    end
-
-    # Exit question listening mode and return running question
-    def stop_listening_for_question!
-      @listening_for_question = false
-      question = ""
-      question << @question_queue.pop until @question_queue.empty?
-      question
-    end
-
-    # @return [String] current discussion still in the @transcription_queue
-    def current_discussion
-      return @current_discussion if @transcription_queue.empty?
-
-      latest_transcriptions = []
-      latest_transcriptions << transcription_queue.pop until transcription_queue.empty?
-      @current_discussion = latest_transcriptions.join.strip
+    def subscribe(&block)
+      @transcription_signal.subscribe(&block)
     end
 
     private
@@ -85,14 +59,11 @@ module PodcastBuddy
       text = @transcriber.process(line)
       return if text.empty?
 
-      if @listening_for_question
-        PodcastBuddy.logger.info "Heard Question: #{text}"
-        @question_queue << text
-      else
-        PodcastBuddy.logger.info "Heard: #{text}"
-        PodcastBuddy.update_transcript(text)
-        @transcription_queue << text
-      end
+      PodcastBuddy.logger.info "Heard: #{text}"
+      PodcastBuddy.update_transcript(text)
+      @transcription_queue << text
+      @transcription_signal.trigger({ text: text, started_at: @listening_start })
+      text
     end
   end
 end

--- a/lib/podcast_buddy/show_assistant.rb
+++ b/lib/podcast_buddy/show_assistant.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module PodcastBuddy
+  # Handles passive podcast assistance including transcription, summarization,
+  # topic extraction, and show notes generation
+  class ShowAssistant
+    attr_reader :listener
+
+    def initialize(session: PodcastBuddy.session)
+      @session = session
+      @listener = PodcastBuddy::Listener.new(transcriber: PodcastBuddy::Transcriber.new)
+      @shutdown = false
+    end
+
+    def start
+      Sync do |task|
+        listener_task = task.async { @listener.start }
+        summarization_task = task.async { periodic_summarization }
+
+        @tasks = [
+          PodcastBuddy::NamedTask.new(name: "Listener", task: listener_task),
+          PodcastBuddy::NamedTask.new(name: "Periodic Summarizer", task: summarization_task)
+        ]
+
+        task.yield until @shutdown
+      end
+    end
+
+    def stop
+      @shutdown = true
+      @listener&.stop
+      @tasks&.each do |task|
+        PodcastBuddy.logger.info "Waiting for #{task.name} to shutdown..."
+        task.task.wait
+      end
+    end
+
+    def summarize_latest
+      current_discussion = @listener.current_discussion
+      return if current_discussion.empty?
+
+      PodcastBuddy.logger.debug "[periodic summarization] Latest transcript: #{current_discussion}"
+      extract_topics_and_summarize(current_discussion)
+    end
+
+    def generate_show_notes
+      return if PodcastBuddy.current_transcript.strip.empty?
+
+      response = PodcastBuddy.openai_client.chat(parameters: {
+        model: "gpt-4o",
+        messages: show_notes_messages,
+        max_tokens: 500
+      })
+      show_notes = response.dig("choices", 0, "message", "content").strip
+      File.open(@session.show_notes_path, "w") do |file|
+        file.puts show_notes
+      end
+
+      PodcastBuddy.logger.info "Show notes saved to: #{@session.show_notes_path}"
+    end
+
+    private
+
+    def periodic_summarization(interval = 15)
+      Async do
+        loop do
+          PodcastBuddy.logger.debug("Shutdown: periodic_summarization...") and break if @shutdown
+
+          sleep interval
+          summarize_latest
+        rescue => e
+          PodcastBuddy.logger.warn "[summarization] periodic summarization failed: #{e.message}"
+        end
+      end
+    end
+
+    def extract_topics_and_summarize(text)
+      Async do |parent|
+        parent.async { update_topics(text) }
+        parent.async { think_about(text) }
+      end
+    end
+
+    def update_topics(text)
+      Async do
+        PodcastBuddy.logger.debug "Looking for topics related to: #{text}"
+        response = PodcastBuddy.openai_client.chat(parameters: {
+          model: "gpt-4o-mini",
+          messages: topic_extraction_messages(text),
+          max_tokens: 500
+        })
+        new_topics = response.dig("choices", 0, "message", "content").gsub("NONE", "").strip
+
+        @session.announce_topics(new_topics)
+        @session.add_to_topics(new_topics)
+      rescue => e
+        PodcastBuddy.logger.error "Failed to update topics: #{e.message}"
+      end
+    end
+
+    def think_about(text)
+      Async do
+        PodcastBuddy.logger.debug "Summarizing current discussion..."
+        response = PodcastBuddy.openai_client.chat(parameters: {
+          model: "gpt-4o",
+          messages: discussion_messages(text),
+          max_tokens: 250
+        })
+        new_summary = response.dig("choices", 0, "message", "content").strip
+        PodcastBuddy.logger.info "Thoughts: #{new_summary}"
+        @session.update_summary(new_summary)
+      rescue => e
+        PodcastBuddy.logger.error "Failed to summarize discussion: #{e.message}"
+      end
+    end
+
+    def topic_extraction_messages(text)
+      [
+        {role: "system", content: PodcastBuddy.config.topic_extraction_system_prompt},
+        {role: "user", content: format(PodcastBuddy.config.topic_extraction_user_prompt, {discussion: text})}
+      ]
+    end
+
+    def discussion_messages(text)
+      [
+        {role: "system", content: format(PodcastBuddy.config.discussion_system_prompt, {summary: PodcastBuddy.current_summary})},
+        {role: "user", content: format(PodcastBuddy.config.discussion_user_prompt, {discussion: text})}
+      ]
+    end
+
+    def show_notes_messages
+      [
+        {role: "system", content: "You are a kind and helpful podcast assistant helping to take notes for the show, and extract useful information being discussed for listeners."},
+        {role: "user", content: "Transcript:\n---\n#{PodcastBuddy.current_transcript}\n---\n\nTopics:\n---\n#{PodcastBuddy.current_topics}\n---\n\nUse the above transcript and topics to create Show Notes in markdown that outline the discussion.  Extract a breif summary that describes the overall conversation, the people involved and their roles, and sentiment of the topics discussed.  Follow the summary with a list of helpful links to any libraries, products, or other resources related to the discussion. Cite sources."}
+      ]
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -23,10 +23,16 @@ RSpec.describe PodcastBuddy::CLI do
   end
 
   describe "#run" do
+    let(:show_assistant) { instance_double(PodcastBuddy::ShowAssistant) }
+
     before do
       allow(PodcastBuddy).to receive(:logger).and_return(Logger.new(nil))
       allow(PodcastBuddy).to receive(:setup)
       allow(PodcastBuddy).to receive(:openai_client).and_return(double(chat: {"choices" => [{"message" => {"content" => "test"}}]}))
+      allow(PodcastBuddy::ShowAssistant).to receive(:new).and_return(show_assistant)
+      allow(show_assistant).to receive(:start)
+      allow(show_assistant).to receive(:stop)
+      allow(show_assistant).to receive(:generate_show_notes)
     end
 
     it "configures logger and session" do
@@ -38,6 +44,12 @@ RSpec.describe PodcastBuddy::CLI do
     it "handles interrupt gracefully" do
       allow(cli).to receive(:start_recording).and_raise(Interrupt)
       expect(cli).to receive(:handle_shutdown)
+      cli.run
+    end
+
+    it "starts and stops show assistant" do
+      allow(cli).to receive(:start_recording).and_raise(Interrupt)
+      expect(show_assistant).to receive(:stop)
       cli.run
     end
   end

--- a/spec/co_host_spec.rb
+++ b/spec/co_host_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PodcastBuddy::CoHost do
+  let(:listener) { instance_double(PodcastBuddy::Listener, subscribe: nil) }
+  let(:audio_service) { instance_double(PodcastBuddy::AudioService) }
+  let(:co_host) { described_class.new(listener: listener, audio_service: audio_service) }
+
+  describe "#initialize" do
+    it "sets up listener and audio service" do
+      expect(co_host.listener).to eq(listener)
+    end
+  end
+
+  describe "#start" do
+    before do
+      allow(listener).to receive(:start).and_return(instance_double(Async::Task))
+      co_host.instance_variable_set(:@listener, listener)
+      allow(PodcastBuddy.logger).to receive(:info)
+      allow(PodcastBuddy.logger).to receive(:debug)
+    end
+
+    it "starts listening for questions"
+  end
+
+  describe "#stop" do
+    it "sets shutdown flag" do
+      co_host.stop
+      expect(co_host.instance_variable_get(:@shutdown)).to be true
+    end
+  end
+end

--- a/spec/fixtures/tmp/2024-12-10_08-32-19/transcript.log
+++ b/spec/fixtures/tmp/2024-12-10_08-32-19/transcript.log
@@ -1,0 +1,1 @@
+test transcription

--- a/spec/fixtures/tmp/2024-12-10_08-32-19/whisper.log
+++ b/spec/fixtures/tmp/2024-12-10_08-32-19/whisper.log
@@ -1,0 +1,1 @@
+# Logfile created on 2024-12-10 08:32:19 -0500 by logger.rb/v1.6.1

--- a/spec/fixtures/tmp/2024-12-10_08-32-53/transcript.log
+++ b/spec/fixtures/tmp/2024-12-10_08-32-53/transcript.log
@@ -1,0 +1,1 @@
+test transcription

--- a/spec/fixtures/tmp/2024-12-10_08-32-53/whisper.log
+++ b/spec/fixtures/tmp/2024-12-10_08-32-53/whisper.log
@@ -1,0 +1,1 @@
+# Logfile created on 2024-12-10 08:32:53 -0500 by logger.rb/v1.6.1

--- a/spec/fixtures/tmp/2024-12-10_09-26-07/transcript.log
+++ b/spec/fixtures/tmp/2024-12-10_09-26-07/transcript.log
@@ -1,0 +1,2 @@
+test transcription
+test transcription

--- a/spec/fixtures/tmp/2024-12-10_09-26-07/whisper.log
+++ b/spec/fixtures/tmp/2024-12-10_09-26-07/whisper.log
@@ -1,0 +1,1 @@
+# Logfile created on 2024-12-10 09:26:07 -0500 by logger.rb/v1.6.1

--- a/spec/listener_spec.rb
+++ b/spec/listener_spec.rb
@@ -8,66 +8,23 @@ RSpec.describe PodcastBuddy::Listener do
   let(:listener) { described_class.new(transcriber: transcriber) }
 
   describe "#initialize" do
-    it "initializes with empty queues and not listening for questions" do
+    it "initializes with empty transcription queue" do
       expect(listener.transcription_queue).to be_empty
-      expect(listener.question_queue).to be_empty
-      expect(listener.listening_for_question).to be false
     end
   end
 
-  describe "#current_discussion" do
-    it "returns the current discussion from the transcription queue" do
-      listener.transcription_queue << "First part. "
-      listener.transcription_queue << "Second part. "
-      expect(listener.current_discussion).to eq("First part. Second part.")
-    end
+  describe "#subscribe" do
+    it "allows subscribing to transcriptions" do
+      received_text = nil
+      listener.subscribe { |data| received_text = data[:text] }
 
-    it "returns an empty string when the transcription queue is empty" do
-      expect(listener.current_discussion).to eq("")
-    end
+      allow(transcriber).to receive(:process).and_return("test transcription")
+      result = listener.send(:process_transcription, "input")
+      # Wait for PodSignal queue
+      sleep 0.01
 
-    it "resets the current discussion on subsequent calls" do
-      listener.transcription_queue << "First part. "
-      expect(listener.current_discussion).to eq("First part.")
-
-      listener.transcription_queue << "Second part. "
-      expect(listener.current_discussion).to eq("Second part.")
-    end
-
-    it "retains the current discussion on subsequent calls without any new queue additions" do
-      listener.transcription_queue << "First part. "
-      expect(listener.current_discussion).to eq("First part.")
-      expect(listener.current_discussion).to eq("First part.")
-    end
-  end
-
-  describe "#listen_for_question!" do
-    it "marks listening_for_question as true" do
-      expect { listener.listen_for_question! }.to change { listener.listening_for_question }.from(false).to(true)
-      expect { listener.listen_for_question! }.not_to change { listener.listening_for_question }
-    end
-
-    it "clears question_queue when toggled on" do
-      listener.question_queue << "test question"
-      expect { listener.listen_for_question! }.to change { listener.question_queue.empty? }.from(false).to(true)
-    end
-  end
-
-  describe "#stop_listening_for_question!" do
-    it "marks listening_for_question as false" do
-      expect { listener.listen_for_question! }.to change { listener.listening_for_question }.from(false).to(true)
-      expect { listener.stop_listening_for_question! }.to change { listener.listening_for_question }.from(true).to(false)
-      expect { listener.stop_listening_for_question! }.not_to change { listener.listening_for_question }
-    end
-
-    it "returns the question" do
-      listener.question_queue << "test question"
-      expect(listener.stop_listening_for_question!).to eq("test question")
-    end
-
-    it "clears the question_queue" do
-      listener.question_queue << "test question"
-      expect { listener.stop_listening_for_question! }.to change { listener.question_queue.empty? }.from(false).to(true)
+      expect(result).to eq("test transcription")
+      expect(received_text).to eq("test transcription")
     end
   end
 
@@ -81,16 +38,9 @@ RSpec.describe PodcastBuddy::Listener do
       expect(listener.transcription_queue.pop).to eq("test transcription")
     end
 
-    it "adds transcription to question_queue when listening for questions" do
-      listener.listen_for_question!
-      expect { listener.send(:process_transcription, "input") }.to change { listener.question_queue.size }.by(1)
-      expect(listener.question_queue.pop).to eq("test transcription")
-    end
-
     it "does not add empty transcriptions to any queue" do
       allow(transcriber).to receive(:process).and_return("")
       expect { listener.send(:process_transcription, "input") }.not_to change { listener.transcription_queue.size }
-      expect { listener.send(:process_transcription, "input") }.not_to change { listener.question_queue.size }
     end
   end
 end

--- a/spec/show_assistant_spec.rb
+++ b/spec/show_assistant_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PodcastBuddy::ShowAssistant do
+  let(:session) { instance_double(PodcastBuddy::Session) }
+  let(:show_assistant) { described_class.new(session: session) }
+
+  describe "#initialize" do
+    it "creates a new listener with transcriber" do
+      expect(show_assistant.instance_variable_get(:@listener)).to be_a(PodcastBuddy::Listener)
+    end
+  end
+
+  describe "#start" do
+    let(:listener) { instance_double(PodcastBuddy::Listener) }
+    let(:listener_task) { instance_double(Async::Task) }
+    let(:summarization_task) { instance_double(Async::Task) }
+
+    before do
+      allow(listener).to receive(:start).and_return(instance_double(Async::Task))
+      show_assistant.instance_variable_set(:@listener, listener)
+    end
+
+    it "starts listener and summarization tasks" do
+      allow(show_assistant).to receive(:periodic_summarization).and_return(instance_double(Async::Task))
+
+      # Simulate Async behavior
+      # Mark shutdown flag so the task doesn't yield and hang
+      show_assistant.instance_variable_set(:@shutdown, true)
+      Sync do |task|
+        show_assistant.start
+      end
+
+      expect(listener).to have_received(:start)
+    end
+  end
+
+  describe "#stop" do
+    let(:listener) { instance_double(PodcastBuddy::Listener) }
+
+    before do
+      allow(session).to receive(:show_notes_path).and_return(File.join("tmp", "show-notes.md"))
+      allow(PodcastBuddy).to receive(:current_transcript).and_return("")
+      allow(PodcastBuddy.logger).to receive(:info)
+      allow(listener).to receive(:stop)
+      show_assistant.instance_variable_set(:@listener, listener)
+    end
+
+    it "sets shutdown flag" do
+      show_assistant.stop
+      expect(show_assistant.instance_variable_get(:@shutdown)).to be true
+    end
+
+    it "stops the listener" do
+      expect(listener).to receive(:stop)
+      show_assistant.stop
+    end
+  end
+
+  describe "#summarize_latest" do
+    let(:listener) { instance_double(PodcastBuddy::Listener) }
+
+    before do
+      allow(listener).to receive(:current_discussion).and_return("test discussion")
+      show_assistant.instance_variable_set(:@listener, listener)
+    end
+
+    it "extracts topics and summarizes when discussion exists" do
+      expect(show_assistant).to receive(:extract_topics_and_summarize).with("test discussion")
+      show_assistant.summarize_latest
+    end
+
+    it "does nothing when discussion is empty" do
+      allow(listener).to receive(:current_discussion).and_return("")
+      expect(show_assistant).not_to receive(:extract_topics_and_summarize)
+      show_assistant.summarize_latest
+    end
+  end
+end

--- a/spec/show_assistant_spec.rb
+++ b/spec/show_assistant_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PodcastBuddy::ShowAssistant do
     let(:listener) { instance_double(PodcastBuddy::Listener) }
 
     before do
-      allow(listener).to receive(:current_discussion).and_return("test discussion")
+      show_assistant.instance_variable_set(:@current_discussion, "test discussion")
       show_assistant.instance_variable_set(:@listener, listener)
     end
 
@@ -72,7 +72,7 @@ RSpec.describe PodcastBuddy::ShowAssistant do
     end
 
     it "does nothing when discussion is empty" do
-      allow(listener).to receive(:current_discussion).and_return("")
+      show_assistant.instance_variable_set(:@current_discussion, "")
       expect(show_assistant).not_to receive(:extract_topics_and_summarize)
       show_assistant.summarize_latest
     end


### PR DESCRIPTION
This effort focuses on allowing users to subscribe to the Listener. In doing so, it moves the question listening toggle out of the Listener class.

- The question toggle now lives in a new CoHost class that handles listening for a question and answer it.
- Show note-taking, like topic and summarization, now happens in a new ShowAssistant class. In the future, we will introduce an interface to allow adding actions that can be taken at specified intervals (like is currently done with summarization and topic extraction).
- Moves periodic summarization, topic extraction, and show notes generation into ShowAssistant class
- Improves separation of concerns between CLI and ShowAssistant
- Adds specs for ShowAssistant class
- Updates CLI to delegate to ShowAssistant for passive podcast assistance