### PR TITLE
Fix whipser setup

### DIFF
--- a/lib/podcast_buddy.rb
+++ b/lib/podcast_buddy.rb
@@ -39,7 +39,12 @@ module PodcastBuddy
       @session = Session.new(name: name)
     end
 
+    def cache_dir
+      @cache_dir ||= "#{ENV["HOME"]}/.buddy"
+    end
+
     def setup
+      Dir.mkdir PodcastBuddy.cache_dir unless Dir.exist?(PodcastBuddy.cache_dir)
       SystemDependency.auto_install!(:git)
       SystemDependency.auto_install!(:sdl2)
       SystemDependency.auto_install!(:whisper)

--- a/lib/podcast_buddy/configuration.rb
+++ b/lib/podcast_buddy/configuration.rb
@@ -86,7 +86,7 @@ module PodcastBuddy
 
     # @return [String]
     def whisper_command
-      "./whisper.cpp/stream -m ./whisper.cpp/models/ggml-#{whisper_model}.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
+      "#{PodcastBuddy.cache_dir}/whisper.cpp/build/bin/stream -m #{PodcastBuddy.cache_dir}/whisper.cpp/models/ggml-#{whisper_model}.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe PodcastBuddy::CLI do
 
   describe "#run" do
     let(:show_assistant) { instance_double(PodcastBuddy::ShowAssistant) }
+    let(:listener) { instance_double(PodcastBuddy::Listener) }
 
     before do
       allow(PodcastBuddy).to receive(:logger).and_return(Logger.new(nil))
@@ -33,6 +34,8 @@ RSpec.describe PodcastBuddy::CLI do
       allow(show_assistant).to receive(:start)
       allow(show_assistant).to receive(:stop)
       allow(show_assistant).to receive(:generate_show_notes)
+      allow(show_assistant).to receive(:listener).and_return(listener)
+      allow(listener).to receive(:subscribe)
     end
 
     it "configures logger and session" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe PodcastBuddy::Configuration do
 
   describe "#whisper_command" do
     it "returns the expected command string" do
-      expected_command = "./whisper.cpp/stream -m ./whisper.cpp/models/ggml-small.en-q5_1.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
+      expected_command = "#{PodcastBuddy.cache_dir}/whisper.cpp/build/bin/stream -m #{PodcastBuddy.cache_dir}/whisper.cpp/models/ggml-small.en-q5_1.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
       expect(config.whisper_command).to eq(expected_command)
     end
 
     it "incorporates changes to whisper_model" do
       config.whisper_model = "test_model"
-      expected_command = "./whisper.cpp/stream -m ./whisper.cpp/models/ggml-test_model.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
+      expected_command = "#{PodcastBuddy.cache_dir}/whisper.cpp/build/bin/stream -m #{PodcastBuddy.cache_dir}/whisper.cpp/models/ggml-test_model.bin -t 8 --step 0 --length 5000 --keep 500 --vad-thold 0.75 --audio-ctx 0 --keep-context -c 1 -l en"
       expect(config.whisper_command).to eq(expected_command)
     end
   end

--- a/spec/fixtures/tmp/2024-12-19_13-39-47/transcript.log
+++ b/spec/fixtures/tmp/2024-12-19_13-39-47/transcript.log
@@ -1,0 +1,2 @@
+test transcription
+test transcription

--- a/spec/fixtures/tmp/session/transcript.log
+++ b/spec/fixtures/tmp/session/transcript.log
@@ -1,1 +1,2 @@
-Existing transcript
+Existing transcripttest transcription
+test transcription


### PR DESCRIPTION
This change introduces a new top-level cache directory (`PodcastBuddy.cache_dir`).  Whipser will now be cloned there, built properly, and store models there.  Having this abstraction helps consolidate the locality of what is being executed.  We may consider moving all artifacts there.